### PR TITLE
makes it so the `compute( map, "property.names")` works.

### DIFF
--- a/can-compute_test.js
+++ b/can-compute_test.js
@@ -3,6 +3,7 @@ var Compute = require('can-compute/proto-compute');
 var QUnit = require('steal-qunit');
 var canBatch = require('can-event/batch/');
 var Observation = require('can-observation');
+var DefineMap = require("can-define/map/map");
 //require('./read_test');
 
 QUnit.module('can/compute');
@@ -956,5 +957,17 @@ test("trace", function(){
 	rootB.set('B');
 	canBatch.stop();
 	grandChild.log();
+
+});
+
+test("compute(defineMap, 'property.names') works (#20)", function(){
+	var map = new DefineMap();
+	var c = compute(map, "foo.bar");
+	c.on("change", function(ev, newVal){
+		QUnit.equal(newVal, 2);
+	});
+
+	map.set("foo", new DefineMap());
+	map.foo.set("bar", 2);
 
 });

--- a/package.json
+++ b/package.json
@@ -47,20 +47,21 @@
   },
   "dependencies": {
     "can-event": "^3.0.0-pre.1",
-    "can-observation": "^3.0.0-pre.6",
-    "can-util": "^3.0.0-pre.21"
+    "can-observation": "^3.0.0-pre.8",
+    "can-util": "^3.0.0-pre.34"
   },
   "devDependencies": {
     "bit-docs": "0.0.6",
-    "jshint": "^2.9.1",
+    "can-define": "^0.7.18",
     "cssify": "^1.0.2",
-    "steal": "^0.16.0",
+    "done-serve": "^0.2.4",
+    "donejs-cli": "^0.9.5",
+    "generator-donejs": "^0.9.0",
+    "jshint": "^2.9.1",
+    "steal": "^0.16.35",
     "steal-qunit": "^0.1.1",
     "steal-tools": "^0.16.0",
-    "testee": "^0.2.4",
-    "generator-donejs": "^0.9.0",
-    "donejs-cli": "^0.9.5",
-    "done-serve": "^0.2.4"
+    "testee": "^0.2.4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
fixes #20