### PR TITLE
not allowing compute to bind to itself when calling `resolve`

### DIFF
--- a/can-compute_test.js
+++ b/can-compute_test.js
@@ -973,3 +973,33 @@ test("compute(defineMap, 'property.names') works (#20)", function(){
 	map.foo.set("bar", 2);
 
 });
+
+test("Async getter causes infinite loop (#28)", function(){
+	var changeCount = 0;
+	var idCompute = compute(1);
+	stop();
+
+	var comp = compute.async(undefined, function(last, resolve) {
+		var id = idCompute();
+
+		setTimeout(function(){
+			resolve(changeCount + '|' + id);
+		});
+
+		resolve(changeCount + '|' + id);
+	}, null);
+
+	comp.bind('change', function(ev, newVal) {
+		changeCount++;
+		comp();
+	});
+
+	setTimeout(function(){
+		idCompute(2);
+	}, 50);
+
+	setTimeout(function() {
+		equal(changeCount, 4);
+		start();
+	}, 100);
+});

--- a/proto-compute.js
+++ b/proto-compute.js
@@ -280,9 +280,9 @@ assign(Compute.prototype, {
 			// that should update the value of the compute (`setValue`). To make this we need
 			// the "normal" updater function because we are about to overwrite it.
 			var oldUpdater = this.updater,
-				setValue = function(newVal) {
+				resolve = Observation.ignore(function(newVal) {
 					oldUpdater.call(self, newVal, self.value);
-				};
+				});
 
 			// Because `setupComputeHandlers` calls `updater` internally with its
 			// observation.value as `oldValue` and that might not be up to date,
@@ -294,7 +294,7 @@ assign(Compute.prototype, {
 
 			bindings = setupComputeHandlers(this, function() {
 				// Call getter, and get new value
-				var res = getter.call(settings.context, self.lastSetValue.get(), setValue);
+				var res = getter.call(settings.context, self.lastSetValue.get(), resolve);
 				// If undefined is returned, don't update the value.
 				return res !== undefined ? res : this.value;
 			}, this);


### PR DESCRIPTION
Closes https://github.com/canjs/can-compute/issues/28.