### PR TITLE
Use can-event.on to listen to property events

### DIFF
--- a/can-compute_test.js
+++ b/can-compute_test.js
@@ -7,6 +7,7 @@ var canBatch = require('can-event/batch/');
 var Observation = require('can-observation');
 var DefineMap = require("can-define/map/map");
 var DefineList = require("can-define/list/list");
+var domDispatch = require("can-util/dom/dispatch/dispatch");
 //require('./read_test');
 
 QUnit.module('can/compute');
@@ -1013,4 +1014,16 @@ test("Async getter causes infinite loop (#28)", function(){
 		equal(changeCount, 4);
 		start();
 	}, 100);
+});
+
+test("Listening to input change", function(){
+	var input = document.createElement("input");
+	var comp = compute(input, "value", "input");
+
+	comp.on("change", function(){
+		ok(true, "it changed");
+	});
+
+	input.value = 'foo';
+	domDispatch.call(input, "input");
 });

--- a/package.json
+++ b/package.json
@@ -24,25 +24,12 @@
     "release:pre": "npm version prerelease && npm publish"
   },
   "main": "can-compute",
-  "browser": {
-    "transform": [
-      "cssify"
-    ]
-  },
-  "browserify": {
-    "transform": [
-      "cssify"
-    ]
-  },
   "keywords": [
     "canjs",
     "canjs-plugin",
     "donejs"
   ],
   "system": {
-    "configDependencies": [
-      "live-reload"
-    ],
     "npmAlgorithm": "flat"
   },
   "dependencies": {
@@ -53,7 +40,6 @@
   "devDependencies": {
     "bit-docs": "0.0.6",
     "can-define": "^0.8.0",
-    "cssify": "^1.0.2",
     "done-serve": "^0.2.5",
     "donejs-cli": "^0.9.5",
     "generator-donejs": "^0.9.0",

--- a/proto-compute.js
+++ b/proto-compute.js
@@ -195,12 +195,12 @@ assign(Compute.prototype, {
 		};
 
 		this._on = function(update) {
-			canEvent.addEventListener.call(target, eventName || propertyName, handler);
+			canEvent.on.call(target, eventName || propertyName, handler);
 			// Set the cached value
 			this.value = this._get();
 		};
 		this._off = function() {
-			return canEvent.removeEventListener.call( target, eventName || propertyName, handler);
+			return canEvent.off.call( target, eventName || propertyName, handler);
 		};
 	},
 	// ## Setup Setter Computes


### PR DESCRIPTION
This makes it so that when listening to property events such as:

```js
compute(input, "value", "change");
```

It uses can-event.on() to listen for changes. can-event.on() will defer
to can-util/dom/events/events if the thing being listened to is a DOM
node.

Fixes #35