### PR TITLE
truthy should not automatically run functions (canjs/can-stache#172)

### DIFF
--- a/can-compute.js
+++ b/can-compute.js
@@ -85,9 +85,6 @@ var COMPUTE = function (getterSetter, context, eventName, bindOnce) {
 COMPUTE.truthy = function (compute) {
 	return COMPUTE(function () {
 		var res = compute();
-		if (typeof res === 'function') {
-			res = res();
-		}
 		return !!res;
 	});
 };

--- a/can-compute_test.js
+++ b/can-compute_test.js
@@ -1027,3 +1027,15 @@ test("Listening to input change", function(){
 	input.value = 'foo';
 	domDispatch.call(input, "input");
 });
+
+test("compute.truthy with functions (canjs/can-stache#172)", function () {
+	var func = compute(function() {
+		return function() {
+			ok(false, "should not be run");
+		};
+	});
+
+	var truthy = compute.truthy(func);
+
+	equal(truthy(), true);
+});


### PR DESCRIPTION
part of fix for canjs/can-stache#172. This does not break any tests in the canjs/canjs test suite.