### PR TITLE
Replace 10ms setTimeout with setImmediate for unbinding temporary computes

### DIFF
--- a/proto-compute.js
+++ b/proto-compute.js
@@ -518,7 +518,7 @@ Compute.temporarilyBind = function (compute) {
 	computeInstance.addEventListener('change', k);
 	if (!computes) {
 		computes = [];
-		setTimeout(unbindComputes, 10);
+		setImmediate(unbindComputes);
 	}
 	computes.push(computeInstance);
 };


### PR DESCRIPTION
This may increase performance in some cases, but is mostly for helping other asynchronous operations in dependent libs (like can-stache-bindings) fire events in a reliable order for testing.