### PR TITLE
add deferred functionality (#81)

### DIFF
--- a/can-compute-deferred-test.js
+++ b/can-compute-deferred-test.js
@@ -1,0 +1,10 @@
+var compute = require('can-compute');
+var QUnit = require('steal-qunit');
+
+QUnit.asyncTest('deferred basics', 2, function() {
+	var foo = compute.deferred();
+
+	QUnit.equal(foo.computeInstance.observation.deferred, true, 'observation is deferred');
+	QUnit.equal(typeof foo.startDeferred, 'function', 'startDeferred method exists');
+	QUnit.equal(typeof foo.stopDeferred, 'function', 'stopDeferred method exists');
+});

--- a/can-compute.js
+++ b/can-compute.js
@@ -98,6 +98,23 @@ COMPUTE.async = function(initialValue, asyncComputer, context){
 	});
 };
 
+// ### deferred
+// A simple helper that makes an deferred compute a bit easier.
+COMPUTE.deferred = function(){
+	var deferred = COMPUTE(undefined, {
+		deferred: true
+	});
+
+	deferred.startDeferred = function() {
+		return this.computeInstance.startDeferred();
+	};
+	deferred.stopDeferred = function() {
+		return this.computeInstance.stopDeferred();
+	};
+
+	return deferred;
+};
+
 // ### compatability
 // Setting methods that should not be around in 3.0.
 COMPUTE.temporarilyBind = Compute.temporarilyBind;

--- a/can-compute_test.js
+++ b/can-compute_test.js
@@ -1,4 +1,5 @@
 require("./can-compute-async-test");
+require("./can-compute-deferred-test");
 
 var compute = require('can-compute');
 var Compute = require('can-compute/proto-compute');


### PR DESCRIPTION
Adds deferred functionality, via can-observation#85. Provides a shortcut for the can-observation syntax, calls `observation.makeDeferred()`, and exposes `startDeferred()` and `stopDeferred()` on the compute and computeInstance for easier usage. Also considers the compute as changed when deferred.