### PR TITLE
Properly handle setting element computes

### DIFF
--- a/can-compute_test.js
+++ b/can-compute_test.js
@@ -1028,6 +1028,14 @@ test("Listening to input change", function(){
 	domDispatch.call(input, "input");
 });
 
+test("Setting an input to change", function(){
+	var input = document.createElement("input");
+	var comp = compute(input, "value", "input");
+
+	comp("foo");
+	ok(input.value === "foo");
+});
+
 test("compute.truthy with functions (canjs/can-stache#172)", function () {
 	var func = compute(function() {
 		return function() {

--- a/proto-compute.js
+++ b/proto-compute.js
@@ -190,9 +190,14 @@ assign(Compute.prototype, {
 		this._set = function(value) {
 			// allow setting properties n levels deep, if separated with dot syntax
 			var properties = propertyName.split("."),
-				leafPropertyName = properties.pop(),
-				targetProperty = getObject(target, properties.join('.'));
-			targetProperty[leafPropertyName] = value;
+				leafPropertyName = properties.pop();
+
+			if(properties.length) {
+				var targetProperty = getObject(target, properties.join('.'));
+				targetProperty[leafPropertyName] = value;
+			} else {
+				target[propertyName] = value;
+			}
 		};
 
 		this._on = function(update) {


### PR DESCRIPTION
This fixes element computes (those that listen to element events), so
that setters can be called in the simple scenario. Fixes #84