### PR TITLE
Used typeof to check for console for IE9

### DIFF
--- a/proto-compute.js
+++ b/proto-compute.js
@@ -477,7 +477,7 @@ assign(Compute.prototype, {
 			if(trace.dependencies && trace.dependencies.length) {
 				currentTrace = trace.cid + " = " + trace.computeValue;
 
-				if(console && console.group) {
+				if(typeof console !== 'undefined' && console.group) {
 					console.group(currentTrace);
 				} else {
 					canLog.log(currentTrace);
@@ -491,7 +491,7 @@ assign(Compute.prototype, {
 					}
 				});
 
-				if(console && console.groupEnd) {
+				if(typeof console !== 'undefined' && console.groupEnd) {
 					console.groupEnd();
 				}
 			} else {


### PR DESCRIPTION
In IE9 window.console is not available unless the dev tools are open and will silently break execution anytime it is referenced.

This used typeof to check for console.

For canjs/canjs#3482