### PR TITLE
Improve behavior Unbind with no arguments

### DIFF
--- a/can-compute.js
+++ b/can-compute.js
@@ -47,10 +47,14 @@ var addEventListener = function(ev, handler){
 };
 
 var removeEventListener = function(ev, handler){
-	return this.computeInstance.removeEventListener(
-		ev,
-		handler && singleReference.getAndDelete(handler, this)
-	);
+		var args = [];
+		if (typeof ev !== 'undefined') {
+			args.push(ev);
+			if (typeof handler !== 'undefined') {
+				args.push(handler);
+			}
+		}
+		return this.computeInstance.removeEventListener.apply(this.computeInstance, args);
 };
 var onValue = function(handler){
 		return this.computeInstance[canOnValueSymbol](handler);

--- a/can-compute_test.js
+++ b/can-compute_test.js
@@ -6,6 +6,7 @@ var QUnit = require('steal-qunit');
 var canBatch = require('can-event/batch/');
 var Observation = require('can-observation');
 var domDispatch = require("can-util/dom/dispatch/dispatch");
+var isEmptyObject = require("can-util/js/is-empty-object/is-empty-object")
 var canSymbol = require("can-symbol");
 var canReflect = require("can-reflect");
 //require('./read_test');
@@ -667,4 +668,14 @@ QUnit.test("can-reflect setValue", function(){
 
 	canReflect.setValue(a, "A");
 	QUnit.equal(a(), "A", "compute");
+});
+
+QUnit.test("Calling .unbind() with no arguments should tear down all event handlers", function () {
+	var count = compute(0);
+  count.on('change', function() {
+		console.log('Count changed');
+	});
+	QUnit.equal(count.computeInstance.__bindEvents.change.length, 1, "Change event added");
+	count.unbind();
+	QUnit.equal(count.computeInstance.__bindEvents.change.length, 0, "All events for compute removed");
 });

--- a/can-compute_test.js
+++ b/can-compute_test.js
@@ -6,7 +6,6 @@ var QUnit = require('steal-qunit');
 var canBatch = require('can-event/batch/');
 var Observation = require('can-observation');
 var domDispatch = require("can-util/dom/dispatch/dispatch");
-var isEmptyObject = require("can-util/js/is-empty-object/is-empty-object")
 var canSymbol = require("can-symbol");
 var canReflect = require("can-reflect");
 //require('./read_test');
@@ -672,7 +671,7 @@ QUnit.test("can-reflect setValue", function(){
 
 QUnit.test("Calling .unbind() with no arguments should tear down all event handlers", function () {
 	var count = compute(0);
-  count.on('change', function() {
+	count.on('change', function() {
 		console.log('Count changed');
 	});
 	QUnit.equal(count.computeInstance.__bindEvents.change.length, 1, "Change event added");

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "can-cid": "^1.0.3",
-    "can-event": "^3.6.0",
+    "can-event": "^3.7.0",
     "can-namespace": "1.0.0",
     "can-observation": "^3.3.1",
     "can-reflect": "^1.2.1",


### PR DESCRIPTION
Calling unbind with no arguments now removes all handlers for the compute.

- Updated can-event version dependency
- Added test