### PR TITLE
Small refactor to proto-compute

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "donejs"
   ],
   "dependencies": {
+    "can-assign": "^1.1.1",
     "can-event-queue": "<2.0.0",
     "can-namespace": "1.0.0",
     "can-observation": "^4.0.0-pre.22",


### PR DESCRIPTION
- Remove can-cid usage
- Use can-assign instead of can-util/js/assign
- Assign all symbols to Compute in a single place