### PR TITLE
Set can-observation._value instead of .value

### DIFF
--- a/proto-compute.js
+++ b/proto-compute.js
@@ -145,7 +145,11 @@ var setupComputeHandlers = function(compute, func, context) {
 		// Call `onchanged` when any source observables change.
 		_on: function() {
 			canReflect.onValue( observation, updater,"notify");
-			compute.value = observation.value;
+			if (observation.hasOwnProperty("_value")) {// can-observation 4.1+
+				compute.value = observation._value;
+			} else {// can-observation < 4.1
+				compute.value = observation.value;
+			}
 		},
 		// Unbind `onchanged` from all source observables.
 		_off: function() {
@@ -296,7 +300,7 @@ assign(Compute.prototype, {
 				});
 
 			// Because `setupComputeHandlers` calls `updater` internally with its
-			// observation.value as `oldValue` and that might not be up to date,
+			// observation._value as `oldValue` and that might not be up to date,
 			// we overwrite updater to always use self.value.
 			this.updater = function(newVal) {
 				oldUpdater.call(self, newVal, self.value);
@@ -421,10 +425,15 @@ assign(Compute.prototype, {
 	// Updates the cached value and fires an event if the value has changed.
 	updater: function(newVal, oldVal, batchNum) {
 		this.value = newVal;
-		if(this.observation) {
+		var observation = this.observation;
+		if (observation) {
 			// it's possible the observation doesn't actually
 			// have any dependencies
-			this.observation.value = newVal;
+			if (observation.hasOwnProperty("_value")) {// can-observation 4.1+
+				observation._value = newVal;
+			} else {// can-observation < 4.1
+				observation.value = newVal;
+			}
 		}
 		updateOnChange(this, newVal, oldVal, batchNum);
 	},


### PR DESCRIPTION
can-observation’s value property is going to be a getter, so now the `._value` property needs to be used.

Related to https://github.com/canjs/can-observation/pull/135